### PR TITLE
Fix new_trans return type

### DIFF
--- a/project4/README.md
+++ b/project4/README.md
@@ -172,7 +172,7 @@ new_states dfa_ex [0; 1] = [[1]; [0]; [2]]
 * **Description:** Given an NFA and a list of states from that NFA (a single state in the DFA) computes all the transitions coming from `qs` (including the dead state) in the DFA.
 * **Examples:**
 ```
-new_trans dfa_ex [0; 1] = [([0; 1], Some 'a', 1); ([0; 1], Some 'b', 0); ([0; 1], Some 'c', [2])]
+new_trans dfa_ex [0; 1] = [([0; 1], Some 'a', [1]); ([0; 1], Some 'b', [0]); ([0; 1], Some 'c', [2])]
 ```
 
 **new_finals nfa qs**


### PR DESCRIPTION
The destinations of all transitions in the list returned by new_trans should be 'q lists.